### PR TITLE
updated r5fss1_0 address in linker and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 APP ?= test.elf
 APP_SOURCES ?= test.c
+R_PROC ?= 18
 
 CROSS_COMPILE ?= arm-none-eabi-
 
@@ -20,12 +21,20 @@ all: $(APP)
 clean:
 	rm -f $(APP)
 
+rproc_clean:
+	sudo echo stop > /sys/class/remoteproc/remoteproc$(R_PROC)/state
+	sudo rm /lib/firmware/$(APP)
+
 $(APP): $(APP_SOURCES) gcc.ld
 	$(CROSS_CC) $(CFLAGS) -Og --specs=nosys.specs --specs=nano.specs -T gcc.ld -o $(APP) $(APP_SOURCES)
 	$(CROSS_SIZE) $(APP)
 	$(CROSS_OBJDUMP) -xd $(APP) > $(APP).lst
-	# sudo cp $(APP) /lib/firmware/
-	# sudo echo stop > /sys/class/remoteproc/remoteproc18/state
-	# sudo echo $(APP) > /sys/class/remoteproc/remoteproc18/firmware
-	# sudo echo start > /sys/class/remoteproc/remoteproc18/state
-	# sudo cat /sys/kernel/debug/remoteproc/remoteproc18/trace0
+
+rproc_start:
+	sudo cp $(APP) /lib/firmware/
+	sudo echo $(APP) > /sys/class/remoteproc/remoteproc$(R_PROC)/firmware
+	sudo echo start > /sys/class/remoteproc/remoteproc$(R_PROC)/state
+	sudo cat /sys/kernel/debug/remoteproc/remoteproc$(R_PROC)/trace0
+
+rproc_trace:
+	sudo cat /sys/kernel/debug/remoteproc/remoteproc$(R_PROC)/trace0

--- a/gcc.ld
+++ b/gcc.ld
@@ -6,7 +6,7 @@
  *   RAM.LENGTH: length of RAM bank 0
  */
 
- __DDR_START__ = 0xA6000000;
+ __DDR_START__ = 0xA4000000;
 
 MEMORY
 {


### PR DESCRIPTION
R5fss1_0 address changed in 6.1 kernel, so the linker needed to be updated to make it work. Updated the Makefile to make it easier to run init commands for the rproc for this firmware and also commands to stop the rproc and see the trace buffer.